### PR TITLE
Add opengraph metadata

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-jupyter-book==0.11.2
-jinja2<3.1
+jupyter-book==0.13.1
+sphinxext-opengraph

--- a/src/_config.yml
+++ b/src/_config.yml
@@ -35,3 +35,12 @@ html:
   comments:
     hypothesis              : false
     utterances              : false
+
+sphinx:
+  extra_extensions:
+  - sphinxext.opengraph
+  config:
+    ogp_site_url: "https://earth-env-data-science.github.io/"
+    ogp_image: "https://earth-env-data-science.github.io/_static/eeds-logo.png"
+    ogp_description_length: 200
+    ogp_use_first_image: true


### PR DESCRIPTION
This PR updates to the latest version of Jupyter Book and adds the opengraph metadata extension, which will enable better previews on social media.

✅  Tested locally and works